### PR TITLE
New option clean-full-catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,14 @@ optional arguments:
                         questions will be answered with YES
   -n REPONAME, --reponame REPONAME
                         The name of the repo which should be cleaned up
+  -cf, --clean-full-catalog
+                        If set all repos of the registry will be cleaned up,
+                        keeping the amount of images specified in -k option. 
+                        The amount for each repo can be overridden in the repofile (-f).
   -k KEEPIMAGES, --keepimages KEEPIMAGES
                         Amount of images (not tags!) which should be kept for
-                        the given repo.
+                        the given repo  (if -n is set) or for each repo of the 
+                        registry (if -cf is set).
   -f REPOSFILE, --reposfile REPOSFILE
                         A file containing the list of Repositories and how
                         many images should be kept.
@@ -121,12 +126,27 @@ Same as above but ignore images which are associated with multiple tags.
 If you have a very large registry and enough bandwidth you can increase the parallel workers to retrieve the image metadata. The default is *6*. Be aware that you can generate a *DoS* on your registry server by increasing to much.
 
 
+Cleaning up all repositories of the registry:
+
+```
+./cleanreg.py -r http://192.168.56.2:5000 -cf -k 5 -i
+```
+This will clean up all repositories, keeping 5 images per repository.
+
+
 Cleaning up multiple repositories defined in a configuration file:
 
 ```
 ./cleanreg.py -r http://192.168.56.2:5000 -f cleanreg-example.conf -i
 ```
 The configuration file has the format `<repository name> <images to keep>`. An example file can be found in the repository.
+
+The configuration file can be used together with the clean-full-catalog option:
+
+```
+./cleanreg.py -r http://192.168.56.2:5000 -cf -k 5 -f cleanreg-example.conf -i
+```
+This will clean the repositories with images to keep as defined in the configuration file and it will additionally clean all other repositories of the registry, keeping 5 images per repository.
 
 
 If you've to use a repositories definition file (parameter `-f`) while using the image distribution you should mount that file into your container:

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -356,10 +356,14 @@ def create_repo_list(cmd_args, regserver):
         found_repos_counts = {}
         with open(cmd_args.reposfile) as repoFile:
             for line in repoFile:
-                if cmd_args.verbose > 2:
-                    print "Import line ", line
-                (reponame, keep) = line.split()
-                found_repos_counts[reponame] = int(keep)
+                line = line.split('#', 1)[0]
+                line = line.strip()
+                if line:
+                    if cmd_args.verbose > 2:
+                        print "Import line ", line
+                    (reponame, keep) = line.split()
+                    found_repos_counts[reponame] = int(keep)
+                    
     if cmd_args.verbose > 1:
         print "These repos will be processed:"
         print found_repos_counts

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -364,8 +364,16 @@ def create_repo_list(cmd_args, regserver):
         print "These repos will be processed:"
         print found_repos_counts
 
+    all_registry_repos = get_all_repos(cmd_args.verbose, regserver, cmd_args.cacert)
+
+    for repo in found_repos_counts.keys():
+        if repo not in all_registry_repos:
+            del found_repos_counts[repo]
+            if cmd_args.verbose > 0:
+                print "Skipping repo {0} because it is not in the catalog.".format(repo)
+
     if cmd_args.ignoretag is True:
-        repos = get_all_repos(cmd_args.verbose, regserver, cmd_args.cacert)
+        repos = all_registry_repos
     else:
         repos = found_repos_counts.keys()
 

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -48,8 +48,13 @@ def parse_arguments():
     parser.add_argument('-q', '--quiet', help="[deprecated] If set no user action will appear and all questions will "
                                               "be answered with YES", default=False, action='store_true')
     parser.add_argument('-n', '--reponame', help="The name of the repo which should be cleaned up")
+    parser.add_argument('-cf', '--clean-full-catalog', help="If set all repos of the registry will be cleaned up, "
+                                                            "keeping the amount of images specified in -k option. "
+                                                            "The amount for each repo can be overridden in the repofile (-f).",
+                                                            default=False, action='store_true', dest='clean_full_catalog')
     parser.add_argument('-k', '--keepimages', help="Amount of images (not tags!) which should be kept "
-                                                   "for the given repo.", type=int)
+                                                   "for the given repo (if -n is set) or for each repo of the "
+                                                   "registry (if -cf is set).", type=int)
     parser.add_argument('-f', '--reposfile', help="A file containing the list of Repositories and "
                                                   "how many images should be kept.")
     parser.add_argument('-c', '--cacert', help="Path to a valid CA certificate file. This is needed if self signed "
@@ -74,18 +79,22 @@ def parse_arguments():
     # check if keepimages is set that it is not negative
     if (args.keepimages is not None) and (args.keepimages < 0):
         parser.error("[-k] has to be a positive integer!")
+    
+    # hackish mutually exclusive group
+    if bool(args.reponame) and bool(args.reposfile):
+        parser.error("[-n] and [-f] cant be used together")
 
     # hackish mutually exclusive group
-    if (args.reponame or (args.keepimages is not None)) and args.reposfile:
-        parser.error("[-n|-k] and [-f] cant be used together")
+    if bool(args.reponame) and bool(args.clean_full_catalog):
+        parser.error("[-n] and [-cf] cant be used together")
 
     # hackish dependent arguments
-    if bool(args.reponame) ^ (args.keepimages is not None):
-        parser.error("[-n] and [-k] has to be used together.")
+    if (bool(args.reponame) or args.clean_full_catalog) ^ (args.keepimages is not None):
+        parser.error("[-n] or [-cf] have to be used together with [-k].")
 
     # hackish dependent arguments
-    if bool(args.reponame or (args.keepimages is not None)) is False and bool(args.reposfile) is False:
-        parser.error("[-n|-k] or [-f] has to be used!")
+    if bool(args.reponame) is False and args.clean_full_catalog is False and bool(args.reposfile) is False:
+        parser.error("[-n|-k] or [-cf|-k] or [-f] has to be used!")
     return args
 
 
@@ -343,17 +352,26 @@ def create_repo_list(cmd_args, regserver):
     :return: A dict in the format repositoryname : amount of images to be kept
              and a list of the repository names
     """
-    if bool(cmd_args.reponame) and (cmd_args.keepimages is not None):
+    found_repos_counts = {}
+    all_registry_repos = get_all_repos(cmd_args.verbose, regserver, cmd_args.cacert)
+
+    if bool(cmd_args.reponame) is True:
         if cmd_args.verbose > 1:
             print "In single repo mode."
             print "Will keep {0} images from repo {1}".format(cmd_args.keepimages, cmd_args.reponame)
         found_repos_counts = {cmd_args.reponame: cmd_args.keepimages}
         if cmd_args.verbose > 2:
             print "repos_counts: ", found_repos_counts
-    else:
+    
+    if cmd_args.clean_full_catalog is True:
+        if cmd_args.verbose > 1:
+            print "Importing all repos of the registries catalog, keeping {0} images per repo.".format(cmd_args.keepimages)
+        for repo in all_registry_repos:
+            found_repos_counts[repo] = cmd_args.keepimages
+            
+    if bool(args.reposfile) is True:
         if cmd_args.verbose > 1:
             print "Will read repo information from file {0}".format(cmd_args.reposfile)
-        found_repos_counts = {}
         with open(cmd_args.reposfile) as repoFile:
             for line in repoFile:
                 line = line.split('#', 1)[0]
@@ -363,17 +381,15 @@ def create_repo_list(cmd_args, regserver):
                         print "Import line ", line
                     (reponame, keep) = line.split()
                     found_repos_counts[reponame] = int(keep)
-                    
+
     if cmd_args.verbose > 1:
         print "These repos will be processed:"
         print found_repos_counts
 
-    all_registry_repos = get_all_repos(cmd_args.verbose, regserver, cmd_args.cacert)
-
     for repo in found_repos_counts.keys():
         if repo not in all_registry_repos:
             del found_repos_counts[repo]
-            if cmd_args.verbose > 0:
+            if cmd_args.verbose > 1:
                 print "Skipping repo {0} because it is not in the catalog.".format(repo)
 
     if cmd_args.ignoretag is True:

--- a/test/config/Dockerfile.testrunner
+++ b/test/config/Dockerfile.testrunner
@@ -1,8 +1,7 @@
 #Image as build-environment
-FROM ubuntu:17.04
+FROM python:2.7
 
-RUN apt-get update && apt-get install -y \
-    curl
+RUN apt-get install -y curl
 
 #Download the Dockerclient, because the tests need docker. The docker socket will be mounted in the testrunner-container later
 RUN mkdir /setup \
@@ -10,5 +9,7 @@ RUN mkdir /setup \
  && curl https://get.docker.com/builds/Linux/i386/docker-latest.tgz -o /setup/docker.tgz \
  && tar -xvzf /setup/docker.tgz \
  && mv /setup/docker/docker /usr/bin/docker
+
+RUN pip install requests
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/test/config/testutil.sh
+++ b/test/config/testutil.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+if [[ -z $CLEANREG_WORKSPACE ]]; then
+    echo "Workspace env variable not set. Expected env variable CLEANREG_WORKSPACE=<directory of cleanreg.py>"  
+    exit 1 
+fi
+
 #Read directoryname of this script
-DIRNAME=$(realpath $(dirname $(echo "${BASH_SOURCE[@]}[0]" | awk '{print $1;}')))
+DIRNAME=$CLEANREG_WORKSPACE/test/config/
 DOCKERFILEPATH="$DIRNAME/docker-registry"
 #REGISTRYDATA="$DIRNAME/registrydata"
 
@@ -13,17 +18,27 @@ DOCKERFILEPATH="$DIRNAME/docker-registry"
 #   None
 #######################################
 function createCleanregImage {
-   docker build -t cleanreg $(realpath $DIRNAME/../..)
+   docker build -t cleanreg $CLEANREG_WORKSPACE
 }
 
 #######################################
-# Runs cleanreg on localhost:5000
+# Runs cleanreg on localhost:5000 inside a Docker container
 # Globals:
 #   None
 # Arguments:
 #   Arguments will be passed to cleanreg
 function runCleanreg {
-   docker run --rm -it --net=host -v $(pwd):/data:ro cleanreg --assume-yes -r http://localhost:5000 -v $@
+   docker run --rm -it --net=host cleanreg --assume-yes -r http://localhost:5000 -v $@
+}
+
+#######################################
+# Runs cleanreg on localhost:5000 locally as pythonscript
+# Globals:
+#   None
+# Arguments:
+#   Arguments will be passed to cleanreg
+function runCleanregPython {
+   python $CLEANREG_WORKSPACE/cleanreg.py --assume-yes -r http://localhost:5000 -v $@
 }
 
 #######################################

--- a/test/runAllTests.sh
+++ b/test/runAllTests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 #######################################
 #Runs a testfile within the testrunner container
@@ -7,7 +8,7 @@
 #  REGISTRYTAG tag of the registry being used
 #######################################
 function runTestFile {
-   docker run --rm -it -e REGISTRYTAG=$2 --net=host -v $(pwd):/data:ro -v /var/run/docker.sock:/var/run/docker.sock:ro testrunner "cd /data/test/tests; ./$1"
+   docker run --rm -it -e REGISTRYTAG=$2 --net=host -v $(pwd):/workspace -e CLEANREG_WORKSPACE=/workspace -v /var/run/docker.sock:/var/run/docker.sock:ro testrunner "cd /workspace/test/tests; ls -la; ./$1"
    EXITCODE=$?
    if [[ $EXITCODE -ne 0 ]]; then
       echo "Test failure"
@@ -17,6 +18,7 @@ function runTestFile {
 
 #Create the testrunner image
 docker build -t testrunner -f ./config/Dockerfile.testrunner ./config
+chmod -R +x ./tests
 cd ..
 
 #Run the testfiles

--- a/test/runAllTests.sh
+++ b/test/runAllTests.sh
@@ -25,3 +25,9 @@ sleep 5
 runTestFile simple_clean.sh 2.6.1
 sleep 5
 runTestFile simple_clean.sh latest
+
+sleep 5
+runTestFile clean_full_catalog.sh 2.6.1
+
+sleep 5
+runTestFile cleanreg_config_check.sh 2.6.1

--- a/test/tests/clean_full_catalog.sh
+++ b/test/tests/clean_full_catalog.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+source ../config/testutil.sh
+
+setUp() {
+   echo "Create images for registry and cleanreg"
+   createRegistryImages
+   createCleanregImage
+}
+
+teardown() {
+  echo "Good bye"
+  stopRegistry
+}
+
+test_CleanFullCatalog_uses_keepNumber_for_all_repos_if_not_specified_in_confFile() {
+   startRegistry
+
+   #setup testdata
+   createTestdata "consul" 1 3
+   createTestdata "elasticsearch" 1 3
+   createTestdata "alpine" 1 3
+   createTestdata "mysql" 1 4
+   createTestdata "mongo" 1 2
+   
+   assertImageExists "consul" 1
+   assertImageExists "consul" 2
+   assertImageExists "consul" 3
+   
+   assertImageExists "elasticsearch" 1
+   assertImageExists "elasticsearch" 2
+   assertImageExists "elasticsearch" 3
+   
+   assertImageExists "alpine" 1
+   assertImageExists "alpine" 2
+   assertImageExists "alpine" 3
+   
+   assertImageExists "mysql" 1
+   assertImageExists "mysql" 2
+   assertImageExists "mysql" 3
+   assertImageExists "mysql" 4
+
+   assertImageExists "mongo" 1
+   assertImageExists "mongo" 2
+
+   # setup conf file
+   tee test.conf <<EOF > /dev/null
+consul 20
+elasticsearch 1
+dummybox 10 
+mongo 1
+EOF
+
+   # run cleanreg with --clean-full-catalog -k 2
+   # keeping 2 images of alpine and mysql, because they are not in the test.conf
+   runCleanreg -f /data/test.conf -vvv --clean-full-catalog -k 2
+   
+   assertImageExists "consul" 1
+   assertImageExists "consul" 2
+   assertImageExists "consul" 3
+   
+   assertImageNotExists "elasticsearch" 1
+   assertImageNotExists "elasticsearch" 2
+   assertImageExists "elasticsearch" 3
+   
+   assertImageNotExists "alpine" 1
+   assertImageExists "alpine" 2
+   assertImageExists "alpine" 3
+   
+   assertImageNotExists "mysql" 1
+   assertImageNotExists "mysql" 2
+   assertImageExists "mysql" 3
+   assertImageExists "mysql" 4
+
+   assertImageNotExists "mongo" 1
+   assertImageExists "mongo" 2
+
+   rm test.conf
+}
+
+
+# load shunit2
+. ../config/shunit2

--- a/test/tests/clean_full_catalog.sh
+++ b/test/tests/clean_full_catalog.sh
@@ -44,7 +44,7 @@ test_CleanFullCatalog_uses_keepNumber_for_all_repos_if_not_specified_in_confFile
    assertImageExists "mongo" 2
 
    # setup conf file
-   tee test.conf <<EOF > /dev/null
+   tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
 consul 20
 elasticsearch 1
 dummybox 10 
@@ -53,7 +53,7 @@ EOF
 
    # run cleanreg with --clean-full-catalog -k 2
    # keeping 2 images of alpine and mysql, because they are not in the test.conf
-   runCleanreg -f /data/test.conf -vvv --clean-full-catalog -k 2
+   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -vvv --clean-full-catalog -k 2
    
    assertImageExists "consul" 1
    assertImageExists "consul" 2
@@ -75,7 +75,6 @@ EOF
    assertImageNotExists "mongo" 1
    assertImageExists "mongo" 2
 
-   rm test.conf
 }
 
 

--- a/test/tests/cleanreg_config_check.sh
+++ b/test/tests/cleanreg_config_check.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+source ../config/testutil.sh
+
+oneTimeSetUp() {
+   echo "Create images for registry and cleanreg"
+   createRegistryImages
+   createCleanregImage
+   startRegistry
+   echo "abc 2" > test.conf
+}
+
+oneTimeTearDown() {
+  echo "Good bye"
+  stopRegistry
+  rm test.conf
+}
+
+test_n_and_f_cant_be_used_together() {  
+   lastLine=$(runCleanreg -f /data/test.conf -n abc | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-n] and [-f] cant be used together" "$lastLine"
+}
+
+test_k_has_to_be_positive() {  
+   lastLine=$(runCleanreg -n abc -k -1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-k] has to be a positive integer!" "$lastLine"
+}
+
+test_n_and_k_works() {  
+   lastLine=$(runCleanreg -n abc -k 1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "Aborted by user or nothing to delete." "$lastLine"
+}
+
+test_n_doesnt_work_without_k() {  
+   lastLine=$(runCleanreg -n abc | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k]." "$lastLine"
+}
+
+test_cf_doesnt_work_without_k() {  
+   lastLine=$(runCleanreg -cf | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k]." "$lastLine"
+}
+
+test_k_doesnt_work_without_cf_or_n() {  
+   lastLine=$(runCleanreg -k 2 | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k]." "$lastLine"
+}
+
+test_n_and_f_cant_be_used_together() {  
+   lastLine=$(runCleanreg -n abc -f /data/test.conf | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-n] and [-f] cant be used together" "$lastLine"
+}
+
+test_cf_and_f_can_be_used_together() {  
+   lastLine=$(runCleanreg -cf -k 2 -f /data/test.conf | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "Aborted by user or nothing to delete." "$lastLine"
+}
+
+test_f_works() {  
+   lastLine=$(runCleanreg -f /data/test.conf | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "Aborted by user or nothing to delete." "$lastLine"
+}
+
+test_either_f_n_or_cf_has_to_be_used() {  
+   lastLine=$(runCleanreg | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-n|-k] or [-cf|-k] or [-f] has to be used!" "$lastLine"
+}
+
+# load shunit2
+. ../config/shunit2

--- a/test/tests/cleanreg_config_check.sh
+++ b/test/tests/cleanreg_config_check.sh
@@ -7,71 +7,70 @@ oneTimeSetUp() {
    createRegistryImages
    createCleanregImage
    startRegistry
-   echo "abc 2" > test.conf
+   echo "abc 2" > $CLEANREG_WORKSPACE/test.conf
 }
 
 oneTimeTearDown() {
   echo "Good bye"
   stopRegistry
-  rm test.conf
 }
 
 test_n_and_f_cant_be_used_together() {  
-   lastLine=$(runCleanreg -f /data/test.conf -n abc | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -n abc 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] and [-f] cant be used together" "$lastLine"
 }
 
 test_k_has_to_be_positive() {  
-   lastLine=$(runCleanreg -n abc -k -1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -n abc -k -1 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-k] has to be a positive integer!" "$lastLine"
 }
 
 test_n_and_k_works() {  
-   lastLine=$(runCleanreg -n abc -k 1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -n abc -k 1 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
 
 test_n_doesnt_work_without_k() {  
-   lastLine=$(runCleanreg -n abc | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -n abc 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k]." "$lastLine"
 }
 
 test_cf_doesnt_work_without_k() {  
-   lastLine=$(runCleanreg -cf | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -cf 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k]." "$lastLine"
 }
 
 test_k_doesnt_work_without_cf_or_n() {  
-   lastLine=$(runCleanreg -k 2 | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -k 2 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k]." "$lastLine"
 }
 
 test_n_and_f_cant_be_used_together() {  
-   lastLine=$(runCleanreg -n abc -f /data/test.conf | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanregPython -n abc -f $CLEANREG_WORKSPACE/test.conf 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] and [-f] cant be used together" "$lastLine"
 }
 
 test_cf_and_f_can_be_used_together() {  
-   lastLine=$(runCleanreg -cf -k 2 -f /data/test.conf | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanregPython -cf -k 2 -f $CLEANREG_WORKSPACE/test.conf 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
 
 test_f_works() {  
-   lastLine=$(runCleanreg -f /data/test.conf | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanregPython -f $CLEANREG_WORKSPACE/test.conf 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
 
 test_either_f_n_or_cf_has_to_be_used() {  
-   lastLine=$(runCleanreg | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n|-k] or [-cf|-k] or [-f] has to be used!" "$lastLine"
 }


### PR DESCRIPTION
Hi Halil,
I added a new feature, hope you like it :)

# New option clean-full-catalog
This adds the -cf option, which will clean up all repos from the registry, keeping the number of images, specified with -k.  
It can be combined with the configuration file. The lines of the configuration file will override the default number (= -k option).

## example
cleaning up all repositories of the registry:
```
./cleanreg.py -r http://192.168.56.2:5000 -cf -k 5 -i
```
This will clean up all repositories, keeping 5 images per repository. 

The configuration file can be used together with the clean-full-catalog option:

```
./cleanreg.py -r http://192.168.56.2:5000 -cf -k 5 -f cleanreg-example.conf -i
```
This will clean the repositories with images to keep as defined in the configuration file and it will additionally clean all other repositories of the registry, keeping 5 images per repository.


# More improvements
+ repos in conf file, which do not exist in the registry, will be ignored and therefore dont lead to an exception anymore
+ you can now add comments, starting with #, in the conf file
+ empty lines in conf file are allowed 
