### PR TITLE
New options for keeping images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2.7-alpine
-RUN pip install requests
+RUN pip install requests PyYAML
 COPY cleanreg.py /cleanreg.py
 COPY LICENSE /LICENSE
 ENTRYPOINT ["/cleanreg.py"]

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Cleaning up multiple repositories defined in a configuration file:
 ```
 ./cleanreg.py -r http://192.168.56.2:5000 -f cleanreg-example.conf -i
 ```
-The configuration file has the format `<repository name> <number of images to keep> <regular expression> <date>`. An example file can be found in the repository.
+The configuration file has the format `<repository name> <number of images to keep> <regular expression> <date>`. An example file can be found in the repository. Use an underscore ("_") for any of the parameters as a wildcard.
 
 The configuration file can be used together with the clean-full-catalog option:
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Download the file *cleanreg.py* or clone this repository to a local directory.
 
 ```
 usage: cleanreg.py [-h] [-v] -r REGISTRY [-p] [-y] [-q] [-n REPONAME]
-                   [-k KEEPIMAGES] [-f REPOSFILE] [-c CACERT] [-i]
-                   [-u BASICAUTHUSER] [-pw BASICAUTHPW] [-w MD_WORKERS]
+                   [-k KEEPIMAGES] [-re REGULAREXPRESSION] [-d DATE]
+                   [-f REPOSFILE] [-c CACERT] [-i] [-u BASICAUTHUSER]
+                   [-pw BASICAUTHPW] [-w MD_WORKERS]
 
 Removes images on a docker registry (v2).
 
@@ -67,6 +68,11 @@ optional arguments:
                         Amount of images (not tags!) which should be kept for
                         the given repo  (if -n is set) or for each repo of the 
                         registry (if -cf is set).
+  -re REGULAREXPRESSION, --regex REGULAREXPRESSION
+                        Image tags matching the regular expression will be kept
+  -d DATE, --date DATE
+                        Keep images which were created since this date.
+                        Format: dd.mm.yyyy
   -f REPOSFILE, --reposfile REPOSFILE
                         A file containing the list of Repositories and how
                         many images should be kept.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ optional arguments:
                         Interpret tagnames as regular expressions for the given
                         repo  (if -n is set) or for each repo of the registry (if
                         -cf is set).
-  -d DATE, --date DATE
-                        Keeps images which were created since this date for
+  -s DATE, --since DATE
+                        Keeps images which were created since then for
                         the given repo  (if -n is set) or for each repo of the
                         registry (if -cf is set).
-                        Format: YYYYMMDD or YYYY-MM-DD
+                        Format: YYYYMMDD, YYYYMMDDThhmmss, YYYY-MM-DD or YYYY-MM-DDThh:mm:ss
   -f REPOSFILE, --reposfile REPOSFILE
                         A yaml file containing the list of Repositories with
                         additional information regarding tags, dates and how many
@@ -85,7 +85,7 @@ optional arguments:
                         Format: REPONAME:
                             tag: TAG
                             keepimages: KEEPIMAGES
-                            date: DATE
+                            keepsince: DATE
   -c CACERT, --cacert CACERT
                         Path to a valid CA certificate file. This is needed if
                         self signed TLS is used in the registry server.
@@ -173,9 +173,9 @@ The configuration file has the format
 <repository name>:
     tag: <tag>
     keepimages: <number of images to keep>
-    date: <date>
+    keepsince: <date>
 ```
-The values for tag, keepimages and date are optional. If the tag should be parsed as a regular expression use the -re flag as shown above. An example file can be found in the repository.
+The values for tag, keepimages and keepsince are optional. If the tag should be parsed as a regular expression use the -re flag as shown above. An example file can be found in the repository.
 
 The configuration file can be used together with the clean-full-catalog option:
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Information about the needed garbage collection is described at [https://docs.do
 
 This tool was implemented and tested on Ubuntu Linux 14.04, 16.04 and on MacOS 10.12 using Python 2.7. It is developed against Docker Registry version [2.5.1](https://github.com/docker/distribution/releases/tag/v2.5.1), but tested against [2.6.1](https://github.com/docker/distribution/releases/tag/v2.6.1) and *latest* (see [https://hub.docker.com/r/library/registry/](https://hub.docker.com/r/library/registry/)).
 
-You need to install the Python module *requests*:
+You need to install the Python modules *requests* and *PyYAML*:
 
 ```
-$ pip install requests
+$ pip install requests PyYAML
 ```
 
 Be sure to configure your registry server to allow deletion (see [https://docs.docker.com/registry/configuration/#/delete](https://docs.docker.com/registry/configuration/#/delete)).
@@ -36,8 +36,8 @@ Be sure to configure your registry server to allow deletion (see [https://docs.d
 Download the file *cleanreg.py* or clone this repository to a local directory.
 
 ```
-usage: cleanreg.py [-h] [-v] -r REGISTRY [-p] [-y] [-q] [-n REPONAME]
-                   [-k KEEPIMAGES] [-re REGULAREXPRESSION] [-d DATE]
+usage: cleanreg.py [-h] [-v] -r REGISTRY [-p] [-y] [-q] [-n REPONAME:TAG]
+                   [-k KEEPIMAGES] [-re] [-d DATE]
                    [-f REPOSFILE] [-c CACERT] [-i] [-u BASICAUTHUSER]
                    [-pw BASICAUTHPW] [-w MD_WORKERS]
 
@@ -58,8 +58,9 @@ optional arguments:
                         will be answered with YES
   -q, --quiet           [deprecated] If set no user action will appear and all
                         questions will be answered with YES
-  -n REPONAME, --reponame REPONAME
-                        The name of the repo which should be cleaned up
+  -n REPONAME, --reponame REPONAME:TAG
+                        The name of the repo which should be cleaned up. Tags
+                        are optional.
   -cf, --clean-full-catalog
                         If set all repos of the registry will be cleaned up,
                         considering the -k, -re and -d options.
@@ -68,20 +69,23 @@ optional arguments:
                         Amount of images (not tags!) which should be kept for
                         the given repo  (if -n is set) or for each repo of the
                         registry (if -cf is set).
-  -re REGULAREXPRESSION, --regex REGULAREXPRESSION
-                        Image tags matching the regular expression will be kept
-                        for the given repo  (if -n is set) or for each repo of
-                        the registry (if -cf is set).
+  -re, --regex
+                        Interpret tagnames as regular expressions for the given
+                        repo  (if -n is set) or for each repo of the registry (if
+                        -cf is set).
   -d DATE, --date DATE
                         Keeps images which were created since this date for
                         the given repo  (if -n is set) or for each repo of the
                         registry (if -cf is set).
-                        Format: dd.mm.yyyy
+                        Format: YYYYMMDD or YYYY-MM-DD
   -f REPOSFILE, --reposfile REPOSFILE
-                        A file containing the list of Repositories and which
-                        images should be kept. Use 0 for -k and _ for -re as
-                        well as -d to ignore that option.
-                        Format: <repo> <KEEPIMAGES> <REGULAREXPRESSION> <DATE>
+                        A yaml file containing the list of Repositories with
+                        additional information regarding tags, dates and how many
+                        images to keep.
+                        Format: REPONAME:
+                            tag: TAG
+                            keepimages: KEEPIMAGES
+                            date: DATE
   -c CACERT, --cacert CACERT
                         Path to a valid CA certificate file. This is needed if
                         self signed TLS is used in the registry server.
@@ -133,10 +137,16 @@ Again: to be secure use the `-i` flag:
 Same as above but ignore images which are associated with multiple tags.
 
 ```
-./cleanreg.py -r http://192.168.56.2:5000 -n mysql -re .*release.* -d 01.01.2018 -k 5 -i
+./cleanreg.py -r http://192.168.56.2:5000 -n mysql:latest -i
 ```
 
-Same as above but images containing the word "release" as well as those created since 01.01.2018 but at least the 5 latest will be kept.
+Will only delete the image mysql which is tagged as latest.
+
+```
+./cleanreg.py -r http://192.168.56.2:5000 -n mysql:.*temp.* -re -d 2018-01-01 -k 5 -i
+```
+
+Removes all images that contain the word "temp" in their tagnames and if they were created before 2018 but at least 5 will be kept in total.
 
 ```
 ./cleanreg.py -r http://192.168.56.2:5000 -n myalpine -k 50 -i -w 12
@@ -156,16 +166,23 @@ This will clean up all repositories, keeping 5 images per repository.
 Cleaning up multiple repositories defined in a configuration file:
 
 ```
-./cleanreg.py -r http://192.168.56.2:5000 -f cleanreg-example.conf -i
+./cleanreg.py -r http://192.168.56.2:5000 -f cleanreg-example.conf -re -i
 ```
-The configuration file has the format `<repository name> <number of images to keep> <regular expression> <date>`. An example file can be found in the repository. Use an underscore ("_") for any of the parameters as a wildcard.
+The configuration file has the format
+```
+<repository name>:
+    tag: <tag>
+    keepimages: <number of images to keep>
+    date: <date>
+```
+The values for tag, keepimages and date are optional. If the tag should be parsed as a regular expression use the -re flag as shown above. An example file can be found in the repository.
 
 The configuration file can be used together with the clean-full-catalog option:
 
 ```
-./cleanreg.py -r http://192.168.56.2:5000 -cf -d 01.01.2018 -f cleanreg-example.conf -i
+./cleanreg.py -r http://192.168.56.2:5000 -cf -d 20180101 -f cleanreg-example.conf -i
 ```
-This will clean the repositories with images to keep as defined in the configuration file and it will additionally clean all other repositories of the registry, keeping images per repository that were created since 01.01.2018.
+This will clean the repositories with images to keep as defined in the configuration file and it will additionally clean all other repositories of the registry, keeping images per repository that were created since 2018.
 
 
 If you've to use a repositories definition file (parameter `-f`) while using the image distribution you should mount that file into your container:

--- a/cleanreg-example.conf
+++ b/cleanreg-example.conf
@@ -1,3 +1,3 @@
 consul 20 excludethistag 01.01.2000
 elasticsearch 20 regularexpression 01.01.2000
-dummybox 10 regularexpression 01.01.2050
+dummybox 0 _ _

--- a/cleanreg-example.conf
+++ b/cleanreg-example.conf
@@ -1,3 +1,0 @@
-consul 20 excludethistag 01.01.2000
-elasticsearch 20 regularexpression 01.01.2000
-dummybox 0 _ _

--- a/cleanreg-example.conf
+++ b/cleanreg-example.conf
@@ -1,3 +1,3 @@
-consul 20
-elasticsearch 20
-dummybox 10
+consul 20 excludethistag 01.01.2000
+elasticsearch 20 regularexpression 01.01.2000
+dummybox 10 regularexpression 01.01.2050

--- a/cleanreg-example.yaml
+++ b/cleanreg-example.yaml
@@ -1,0 +1,9 @@
+consul:
+  tag: OnlyThisTag
+  keepimages: 20
+  date: 2000-12-24
+elasticsearch:
+  keepimages: 20
+  date: 20000101
+dummybox:
+  keepimages: 0

--- a/cleanreg-example.yaml
+++ b/cleanreg-example.yaml
@@ -1,9 +1,9 @@
 consul:
   tag: OnlyThisTag
   keepimages: 20
-  date: 2000-12-24
+  keepsince: 2000-12-24T12:31:59
 elasticsearch:
   keepimages: 20
-  date: 20000101
+  keepsince: 20000101
 dummybox:
   keepimages: 0

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -56,8 +56,8 @@ def parse_arguments():
     parser.add_argument('-k', '--keepimages', help="Amount of images (not tags!) which should be kept "
                                                    "for the given repo (if -n is set) or for each repo of the "
                                                    "registry (if -cf is set).", type=int)
-    parser.add_argument('-re', '--regex', help="Image tags matching the regular expression will be kept")
-    parser.add_argument('-d', '--date', help="Keep images which were created since this date. Format: dd.mm.yyyy")
+    parser.add_argument('-re', '--regex', help="Image tags matching the regular expression will be kept", default=None)
+    parser.add_argument('-d', '--date', help="Keep images which were created since this date. Format: dd.mm.yyyy", default=None)
     parser.add_argument('-f', '--reposfile', help="A file containing the list of Repositories and "
                                                   "how many images should be kept.")
     parser.add_argument('-c', '--cacert', help="Path to a valid CA certificate file. This is needed if self signed "
@@ -560,9 +560,10 @@ def get_deletiontags(verbose, tags_dates_digests, repo, repo_count, regex, date)
         if regex is not None:
             deletion_tags = {k: deletion_tags[k] for k in deletion_tags if not re.match(regex, k)}
         if date is not None:
+            parsed_date = datetime.strptime(date, '%d.%m.%Y')
             for tag in deletion_tags.keys():
                 tag_date = datetime.strptime(deletion_tags[tag]['date'].split('T')[0], '%Y-%m-%d')
-                if tag_date >= date:
+                if tag_date >= parsed_date:
                     del deletion_tags[tag]
         print deletion_tags
         #deletion_tags = {k: deletion_tags[k] for k in deletion_tags if not deletion_tags[}
@@ -617,7 +618,7 @@ if __name__ == '__main__':
         if args.verbose > 0:
             print
             print "will delete repo {0} and keep {1} images.".format(repo, count)
-        del_tags = get_deletiontags(args.verbose, repo_tags_dates_digest[repo], repo, count, args.regex, datetime.strptime(args.date, '%d.%m.%Y'))
+        del_tags = get_deletiontags(args.verbose, repo_tags_dates_digest[repo], repo, count, args.regex, args.date)
 
         if len(del_tags) > 0:
             repo_del_tags[repo] = del_tags

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -92,7 +92,7 @@ def parse_arguments():
         parser.error("[-n] and [-cf] cant be used together")
 
     # hackish dependent arguments
-    if (bool(args.reponame) or args.clean_full_catalog) ^ (args.keepimages is not None):
+    if (bool(args.reponame) or args.clean_full_catalog) ^ (args.keepimages is not None or args.regex is not None or args.date is not None):
         parser.error("[-n] or [-cf] have to be used together with [-k].")
 
     # hackish dependent arguments
@@ -551,6 +551,9 @@ def get_deletiontags(verbose, tags_dates_digests, repo, repo_count, regex, date)
         ammount_tags = 0
     else:
         ammount_tags = len(all_tags)
+
+    if repo_count is None:
+        repo_count = 0
 
     if verbose > 1:
         print "Repo {0}: ammount_tags : {1}; repo_count: {2}".format(repo, ammount_tags, repo_count)

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -576,7 +576,7 @@ def get_deletiontags(verbose, tags_dates_digests, repo, repo_count, regex, date)
 
     if ammount_tags > repo_count:
         deletion_tags = collections.OrderedDict(islice(all_tags.iteritems(), ammount_tags - repo_count))
-        if regex is not None and regex != "_":
+        if regex is not None and regex != "_" and regex != "":
             deletion_tags = {k: deletion_tags[k] for k in deletion_tags if not re.match(regex, k)}
         if date is not None and date != "_":
             parsed_date = datetime.strptime(date, '%d.%m.%Y')

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -87,19 +87,8 @@ def parse_arguments():
 
     # check if date is valid
     if args.since is not None:
-        try:
-            datetime.strptime(args.since, '%Y%m%d')
-        except ValueError:
-            try:
-                datetime.strptime(args.since, '%Y-%m-%d')
-            except ValueError:
-                try:
-                    datetime.strptime(args.since, '%Y%m%dT%H%M%S')
-                except ValueError:
-                    try:
-                        datetime.strptime(args.since, '%Y-%m-%dT%H:%M:%S')
-                    except ValueError:
-                        parser.error("[-s] format does not match")
+        if parse_date(args.since) == "":
+            parser.error("[-s] format does not match")
     
     # hackish mutually exclusive group
     if bool(args.reponame) and bool(args.reposfile):
@@ -120,6 +109,28 @@ def parse_arguments():
     if bool(args.reponame) is False and args.clean_full_catalog is False and bool(args.reposfile) is False:
         parser.error("[-n|-k] or [-cf|-k] or [-f] has to be used!")
     return args
+
+
+def parse_date(date_string):
+    """
+    Converts a string to datetime
+    :param date_string: Date as string
+    :return: datetime or empty string if date_string is in an invalid format
+    """
+    try:
+        date = datetime.strptime(date_string, '%Y%m%d')
+    except ValueError:
+        try:
+            date = datetime.strptime(date_string, '%Y-%m-%d')
+        except ValueError:
+            try:
+                date = datetime.strptime(date_string, '%Y%m%dT%H%M%S')
+            except ValueError:
+                try:
+                    date = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%S')
+                except ValueError:
+                    return ""
+    return date
 
 
 def update_progress(current, maximum, factor=2):
@@ -612,16 +623,7 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, keep_count, reg
     elif not regex and tagname != "":
         deletion_tags = {k: deletion_tags[k] for k in deletion_tags if tagname == k}
     if since is not None and since != "":
-        try:
-            parsed_date = datetime.strptime(since, '%Y%m%d')
-        except ValueError:
-            try:
-                parsed_date =  datetime.strptime(since, '%Y-%m-%d')
-            except ValueError:
-                try:
-                    parsed_date = datetime.strptime(args.since, '%Y%m%dT%H%M%S')
-                except ValueError:
-                    parsed_date = datetime.strptime(args.since, '%Y-%m-%dT%H:%M:%S')
+        parsed_date = parse_date(since)
         for tag in deletion_tags.keys():
             tag_date = datetime.strptime(deletion_tags[tag]['date'].split('.')[0], '%Y-%m-%dT%H:%M:%S')
             print "Date: {0}".format(tag_date)

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -92,7 +92,7 @@ def parse_arguments():
             try:
                 datetime.strptime(args.date, '%Y-%m-%d')
             except ValueError:
-                parser.error("[-d] format should be YYYYMMDD")
+                parser.error("[-d] format should be YYYYMMDD or YYYY-MM-DD")
     
     # hackish mutually exclusive group
     if bool(args.reponame) and bool(args.reposfile):
@@ -104,7 +104,8 @@ def parse_arguments():
 
     # hackish dependent arguments
     if (bool(args.reponame) or args.clean_full_catalog) ^ (args.keepimages is not 0 or args.regex is True or args.date is not None):
-        parser.error("[-n] or [-cf] have to be used together with [-k], [-re] or [-d].")
+        if not (bool(args.reposfile) and args.regex):
+            parser.error("[-n] or [-cf] have to be used together with [-k], [-re] or [-d].")
 
     # hackish dependent arguments
     if bool(args.reponame) is False and args.clean_full_catalog is False and bool(args.reposfile) is False:

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -488,11 +488,10 @@ def get_tags_dates_digests_byrepo(verbose, regserver, repo, results, digests, md
     if verbose > 0:
         print "Retrieving metada for repository ", repo
 
-    if tags_all is not None:
-        funcpart = partial(retrieve_metadata, verbose=verbose, regserver=regserver, repo=repo,
-                           managed_tags_date_digests=managed_tags_date_digests,
-                           managed_digests=digests, cacert=cacert)
-        pool.map(funcpart, tags_all)
+    funcpart = partial(retrieve_metadata, verbose=verbose, regserver=regserver, repo=repo,
+                       managed_tags_date_digests=managed_tags_date_digests,
+                       managed_digests=digests, cacert=cacert)
+    pool.map(funcpart, tags_all)
 
     # convert managed dict to a "normal dict" and put it into the other managed dict...
     # Feels so unpythonic, should rewrite the stuff
@@ -541,10 +540,7 @@ def get_all_tags_dates_digests(verbose, regserver, repositories, md_workers, cac
     for repo in repositories:
         if verbose > 0:
             print "Retrieving results..."
-        if repo in repos_tags_digest:
-            result[repo] = repos_tags_digest[repo]
-        else:
-            print "Repo {0} seems to contain invalid tags which will be skipped.".format(repo)
+        result[repo] = repos_tags_digest[repo]
 
     return result, managed_digests
 
@@ -591,8 +587,6 @@ def get_deletiontags(verbose, tags_dates_digests, repo, repo_count, regex, date)
                 tag_date = datetime.strptime(deletion_tags[tag]['date'].split('T')[0], '%Y-%m-%d')
                 if tag_date >= parsed_date:
                     del deletion_tags[tag]
-        print deletion_tags
-        #deletion_tags = {k: deletion_tags[k] for k in deletion_tags if not deletion_tags[}
         if verbose > 1:
             print
             print "Deletion candidates for repo {0}".format(repo)
@@ -644,9 +638,7 @@ if __name__ == '__main__':
         if args.verbose > 0:
             print
             print "will delete repo {0} and keep at least {1} images.".format(repo, count)
-        del_tags = {}
-        if repo in repo_tags_dates_digest:
-            del_tags = get_deletiontags(args.verbose, repo_tags_dates_digest[repo], repo, count, regex, date)
+        del_tags = get_deletiontags(args.verbose, repo_tags_dates_digest[repo], repo, count, regex, date)
 
         if len(del_tags) > 0:
             repo_del_tags[repo] = del_tags

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -565,7 +565,7 @@ def get_all_tags_dates_digests(verbose, regserver, repositories, md_workers, cac
     return result, managed_digests
 
 
-def get_deletiontags(verbose, tags_dates_digests, repo, tagname, repo_count, regex, date):
+def get_deletiontags(verbose, tags_dates_digests, repo, tagname, keep_count, regex, date):
     """
     Returns a dict containing a list of the tags which could be deleted due
     to name and date.
@@ -574,7 +574,7 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, repo_count, reg
     :param verbose: The verbosity level
     :param repo: the repository name
     :param tagname: tag of the repo
-    :param repo_count: amount of tags to be kept in repository
+    :param keep_count: amount of tags to be kept in repository
     :param regex: True if tagnames should be interpreted as regular expressions
     :param date: Keeps tags which were created since this date
     :return: a dict of tags to be deleted, their digest and the date then they are created
@@ -592,11 +592,11 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, repo_count, reg
     else:
         ammount_tags = len(all_tags)
 
-    if repo_count is None:
-        repo_count = 0
+    if keep_count is None:
+        keep_count = 0
 
     if verbose > 1:
-        print "Repo {0}: ammount_tags : {1}; repo_count: {2}".format(repo, ammount_tags, repo_count)
+        print "Repo {0}: ammount_tags : {1}; repo_count: {2}".format(repo, ammount_tags, keep_count)
 
     deletion_tags = all_tags
     if regex and tagname != "":
@@ -614,11 +614,11 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, repo_count, reg
             if tag_date >= parsed_date:
                 del deletion_tags[tag]
 
-    if len(deletion_tags) > (ammount_tags - repo_count):
-        if ammount_tags - repo_count < 0:
+    if len(deletion_tags) > (ammount_tags - keep_count):
+        if ammount_tags <= keep_count:
             deletion_tags.clear()
         else:
-            deletion_tags = collections.OrderedDict(islice(deletion_tags.iteritems(), ammount_tags - repo_count))
+            deletion_tags = collections.OrderedDict(islice(deletion_tags.iteritems(), ammount_tags - keep_count))
         if verbose > 1:
             print
             print "Deletion candidates for repo {0}".format(repo)

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -110,11 +110,13 @@ def parse_arguments():
         parser.error("[-n] and [-cf] cant be used together")
 
     # hackish dependent arguments
+    # Either using reponame/clean_full_catalog or keepimages/regex/since is not allowed unless using a reposfile with a regular expression
     if (bool(args.reponame) or args.clean_full_catalog) ^ (args.keepimages is not 0 or args.regex is True or args.since is not None):
         if not (bool(args.reposfile) and args.regex):
             parser.error("[-n] or [-cf] have to be used together with [-k], [-re] or [-s].")
 
     # hackish dependent arguments
+    # Either one of these parameters has to be used
     if bool(args.reponame) is False and args.clean_full_catalog is False and bool(args.reposfile) is False:
         parser.error("[-n|-k] or [-cf|-k] or [-f] has to be used!")
     return args
@@ -626,11 +628,15 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, keep_count, reg
             if tag_date >= parsed_date:
                 del deletion_tags[tag]
 
-    if len(deletion_tags) > (ammount_tags - keep_count):
+    # considers keep_count to check if too many images are marked for deletion
+    delete_count = ammount_tags - keep_count
+    if len(deletion_tags) > delete_count:
         if ammount_tags <= keep_count:
+            # keep all images
             deletion_tags.clear()
         else:
-            deletion_tags = collections.OrderedDict(islice(deletion_tags.iteritems(), ammount_tags - keep_count))
+            # removes the last keep_count tags from deletion_tags
+            deletion_tags = collections.OrderedDict(islice(deletion_tags.iteritems(), delete_count))
         if verbose > 1:
             print
             print "Deletion candidates for repo {0}".format(repo)

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -124,7 +124,7 @@ def parse_arguments():
 
 def update_progress(current, maximum, factor=2):
     if maximum is 0:
-        raise Exception('Maximum ammount should not be zero.')
+        raise Exception('Maximum amount should not be zero.')
     progress = (100 * current) / maximum
     sys.stdout.write('\r{0}>> {1}%'.format('=' * (progress / factor), progress))
     sys.stdout.flush()
@@ -480,7 +480,7 @@ def get_tags_dates_digests_byrepo(verbose, regserver, repo, results, digests, md
     :param repo: The repository name
     :param results: A managed dict which is used to return a dict containing the tag, date and digest
     :param digests: A managed list which contains a list of all found digests, used to check for multiple usage
-    :param md_workers: Ammount of parallel workers to retrieve metadata
+    :param md_workers: Amount of parallel workers to retrieve metadata
     :param cacert: The path to the certificate file
     :return: Returns using the managed collections results and digests
     """
@@ -508,11 +508,11 @@ def get_tags_dates_digests_byrepo(verbose, regserver, repo, results, digests, md
         print "Found tags for repo {0}: {1} ".format(repo, tags_all)
 
     if tags_all is None:
-        ammount_tags = 0
+        amount_tags = 0
     else:
-        ammount_tags = len(tags_all)
+        amount_tags = len(tags_all)
     if verbose > 2:
-        print "ammount_tags : ", ammount_tags
+        print "amount_tags : ", amount_tags
     if verbose > 0:
         print "Retrieving metada for repository ", repo
 
@@ -596,15 +596,15 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, keep_count, reg
         # for (k, v) in all_tags.iteritems():
 
     if all_tags is None:
-        ammount_tags = 0
+        amount_tags = 0
     else:
-        ammount_tags = len(all_tags)
+        amount_tags = len(all_tags)
 
     if keep_count is None:
         keep_count = 0
 
     if verbose > 1:
-        print "Repo {0}: ammount_tags : {1}; repo_count: {2}".format(repo, ammount_tags, keep_count)
+        print "Repo {0}: amount_tags : {1}; repo_count: {2}".format(repo, amount_tags, keep_count)
 
     deletion_tags = all_tags
     if regex and tagname != "":
@@ -629,9 +629,9 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, keep_count, reg
                 del deletion_tags[tag]
 
     # considers keep_count to check if too many images are marked for deletion
-    delete_count = ammount_tags - keep_count
+    delete_count = amount_tags - keep_count
     if len(deletion_tags) > delete_count:
-        if ammount_tags <= keep_count:
+        if amount_tags <= keep_count:
             # keep all images
             deletion_tags.clear()
         else:

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -607,7 +607,10 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, repo_count, reg
                 del deletion_tags[tag]
 
     if len(deletion_tags) > (ammount_tags - repo_count):
-        deletion_tags = collections.OrderedDict(islice(deletion_tags.iteritems(), ammount_tags - repo_count))
+        if ammount_tags - repo_count < 0:
+            deletion_tags.clear()
+        else:
+            deletion_tags = collections.OrderedDict(islice(deletion_tags.iteritems(), ammount_tags - repo_count))
         if verbose > 1:
             print
             print "Deletion candidates for repo {0}".format(repo)

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -362,10 +362,10 @@ def create_repo_list(cmd_args, regserver):
         if cmd_args.verbose > 1:
             print "In single repo mode."
             print "Will keep {0} images from repo {1}".format(cmd_args.keepimages, cmd_args.reponame)
-        found_repos_counts = {cmd_args.reponame: (0, ", ")}
-        if cmd_args.keep_images is not None:
+        found_repos_counts = {cmd_args.reponame: (0, "", "")}
+        if cmd_args.keepimages is not None:
             (c, r, d) = found_repos_counts[cmd_args.reponame]
-            found_repos_counts[cmd_args.reponame] = (cmd_args.keep_images, r, d)
+            found_repos_counts[cmd_args.reponame] = (cmd_args.keepimages, r, d)
         if cmd_args.regex is not None:
             (c, r, d) = found_repos_counts[cmd_args.reponame]
             found_repos_counts[cmd_args.reponame] = (c, cmd_args.regex, d)

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -87,9 +87,12 @@ def parse_arguments():
     # check if date is valid
     if args.date is not None:
         try:
-            datetime.strptime(args.date, '%d.%m.%Y')
+            datetime.strptime(args.date, '%Y%m%d')
         except ValueError:
-            parser.error("[-d] format should be DD.MM.YYYY")
+            try:
+                datetime.strptime(args.date, '%Y-%m-%d')
+            except ValueError:
+                parser.error("[-d] format should be YYYYMMDD")
     
     # hackish mutually exclusive group
     if bool(args.reponame) and bool(args.reposfile):
@@ -369,7 +372,7 @@ def create_repo_list(cmd_args, regserver):
     if bool(cmd_args.reponame) is True:
         if cmd_args.verbose > 1:
             print "In single repo mode."
-            print "Will keep matching images from repo {1}".format(cmd_args.reponame)
+            print "Will keep matching images from repo {0}".format(cmd_args.reponame)
 
         splittedNames = cmd_args.reponame.split(':')
         repo = splittedNames[0]
@@ -593,8 +596,12 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, repo_count, reg
         elif not regex and tagname != "":
             deletion_tags = {k: deletion_tags[k] for k in deletion_tags if tagname == k}
         if date is not None and date != "_" and date != "":
-            parsed_date = datetime.strptime(date, '%d.%m.%Y')
+            try:
+                parsed_date = datetime.strptime(date, '%Y%m%d')
+            except ValueError:
+                parsed_date =  datetime.strptime(date, '%Y-%m-%d')
             for tag in deletion_tags.keys():
+                print deletion_tags[tag]['date']
                 tag_date = datetime.strptime(deletion_tags[tag]['date'].split('T')[0], '%Y-%m-%d')
                 if tag_date >= parsed_date:
                     del deletion_tags[tag]

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -590,24 +590,24 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, repo_count, reg
     if verbose > 1:
         print "Repo {0}: ammount_tags : {1}; repo_count: {2}".format(repo, ammount_tags, repo_count)
 
-        deletion_tags = all_tags
-        if regex and tagname != "":
-            deletion_tags = {k: deletion_tags[k] for k in deletion_tags if re.match(tagname, k)}
-        elif not regex and tagname != "":
-            deletion_tags = {k: deletion_tags[k] for k in deletion_tags if tagname == k}
-        if date is not None and date != "_" and date != "":
-            try:
-                parsed_date = datetime.strptime(date, '%Y%m%d')
-            except ValueError:
-                parsed_date =  datetime.strptime(date, '%Y-%m-%d')
-            for tag in deletion_tags.keys():
-                print deletion_tags[tag]['date']
-                tag_date = datetime.strptime(deletion_tags[tag]['date'].split('T')[0], '%Y-%m-%d')
-                if tag_date >= parsed_date:
-                    del deletion_tags[tag]
+    deletion_tags = all_tags
+    if regex and tagname != "":
+        deletion_tags = {k: deletion_tags[k] for k in deletion_tags if re.match(tagname, k)}
+    elif not regex and tagname != "":
+        deletion_tags = {k: deletion_tags[k] for k in deletion_tags if tagname == k}
+    if date is not None and date != "_" and date != "":
+        try:
+            parsed_date = datetime.strptime(date, '%Y%m%d')
+        except ValueError:
+            parsed_date =  datetime.strptime(date, '%Y-%m-%d')
+        for tag in deletion_tags.keys():
+            print deletion_tags[tag]['date']
+            tag_date = datetime.strptime(deletion_tags[tag]['date'].split('T')[0], '%Y-%m-%d')
+            if tag_date >= parsed_date:
+                del deletion_tags[tag]
 
     if len(deletion_tags) > (ammount_tags - repo_count):
-        deletion_tags = collections.OrderedDict(islice(deletion_tags.iteritems(), len(deletion_tags) - (ammount_tags - repo_count)))
+        deletion_tags = collections.OrderedDict(islice(deletion_tags.iteritems(), ammount_tags - repo_count))
         if verbose > 1:
             print
             print "Deletion candidates for repo {0}".format(repo)

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -49,7 +49,7 @@ def parse_arguments():
                         action='store_true', dest="assumeyes")
     parser.add_argument('-q', '--quiet', help="[deprecated] If set no user action will appear and all questions will "
                                               "be answered with YES", default=False, action='store_true')
-    parser.add_argument('-n', '--reponame', help="The name of the repo which should be cleaned up")
+    parser.add_argument('-n', '--reponame', help="The name of the repo which should be cleaned up. Tags are optional.")
     parser.add_argument('-cf', '--clean-full-catalog', help="If set all repos of the registry will be cleaned up, "
                                                             "keeping the amount of images specified in -k option. "
                                                             "The amount for each repo can be overridden in the repofile (-f).",
@@ -57,11 +57,11 @@ def parse_arguments():
     parser.add_argument('-k', '--keepimages', help="Amount of images (not tags!) which should be kept "
                                                    "for the given repo (if -n is set) or for each repo of the "
                                                    "registry (if -cf is set).", default=0, type=int)
-    parser.add_argument('-re', '--regex', help="Use a regular expression as a tagname", default=False,
+    parser.add_argument('-re', '--regex', help="Interpret tagnames as regular expressions", default=False,
                         action='store_true', dest="regex")
-    parser.add_argument('-d', '--date', help="Keep images which were created since this date. Format: dd.mm.yyyy", default=None)
-    parser.add_argument('-f', '--reposfile', help="A file containing the list of Repositories and "
-                                                  "how many images should be kept.")
+    parser.add_argument('-d', '--date', help="Keep images which were created since this date. Format: YYYYMMDD or YYYY-MM-DD", default=None)
+    parser.add_argument('-f', '--reposfile', help="A yaml file containing the list of Repositories with additional information "
+                                                  "regarding tags, dates and how many images to keep.")
     parser.add_argument('-c', '--cacert', help="Path to a valid CA certificate file. This is needed if self signed "
                                                "TLS is used in the registry server.", default=None)
     parser.add_argument('-i', '--ignore-ref-tags', help="Ignore a digest if it is referenced multiple times "

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -619,7 +619,9 @@ def get_deletiontags(verbose, tags_dates_digests, repo, tagname, keep_count, reg
 
     deletion_tags = all_tags
     if regex and tagname != "":
-        deletion_tags = {k: deletion_tags[k] for k in deletion_tags if re.match(tagname, k)}
+        for tag in deletion_tags.keys():
+            if not re.match(tagname, tag):
+                del deletion_tags[tag]
     elif not regex and tagname != "":
         deletion_tags = {k: deletion_tags[k] for k in deletion_tags if tagname == k}
     if since is not None and since != "":

--- a/test/config/Dockerfile.testrunner
+++ b/test/config/Dockerfile.testrunner
@@ -10,6 +10,6 @@ RUN mkdir /setup \
  && tar -xvzf /setup/docker.tgz \
  && mv /setup/docker/docker /usr/bin/docker
 
-RUN pip install requests
+RUN pip install requests PyYAML
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/test/tests/clean_full_catalog.sh
+++ b/test/tests/clean_full_catalog.sh
@@ -57,7 +57,7 @@ test_CleanFullCatalog_uses_keepNumber_for_all_repos_if_not_specified_in_confFile
 
    # setup conf file
    tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
-consol:
+consul:
     keepimages: 20
 elasticsearch:
     keepimages: 1

--- a/test/tests/clean_full_catalog.sh
+++ b/test/tests/clean_full_catalog.sh
@@ -67,7 +67,7 @@ mongo:
     keepimages: 1
 postgres:
     keepimages: 0
-    date: `date +%Y%m%d`
+    keepsince: `date +%Y%m%d`
 redis:
     tag: 2
     keepimages: 0
@@ -75,7 +75,7 @@ EOF
 
    # run cleanreg with --clean-full-catalog -k 2
    # keeping 2 images of alpine and mysql, because they are not in the test.conf
-   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -vvv --clean-full-catalog -k 2 -re -d $((`date +%Y`+1))`date +%m%d`
+   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -vvv --clean-full-catalog -k 2 -re -s $((`date +%Y`+1))`date +%m%d`
 
    assertImageExists "consul" 1
    assertImageExists "consul" 2

--- a/test/tests/clean_full_catalog.sh
+++ b/test/tests/clean_full_catalog.sh
@@ -57,12 +57,20 @@ test_CleanFullCatalog_uses_keepNumber_for_all_repos_if_not_specified_in_confFile
 
    # setup conf file
    tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
-consul 20 _
-elasticsearch 1 _
-dummybox 10 _
-mongo 1 _
-postgres 0 `date +%Y%m%d`
-redis:2 0 _
+consol:
+    keepimages: 20
+elasticsearch:
+    keepimages: 1
+dummybox:
+    keepimages: 10
+mongo:
+    keepimages: 1
+postgres:
+    keepimages: 0
+    date: `date +%Y%m%d`
+redis:
+    tag: 2
+    keepimages: 0
 EOF
 
    # run cleanreg with --clean-full-catalog -k 2

--- a/test/tests/clean_full_catalog.sh
+++ b/test/tests/clean_full_catalog.sh
@@ -61,7 +61,7 @@ consul 20 _
 elasticsearch 1 _
 dummybox 10 _
 mongo 1 _
-postgres 0 `date +%%Y%m%d`
+postgres 0 `date +%Y%m%d`
 redis:2 0 _
 EOF
 
@@ -84,7 +84,7 @@ EOF
 
    assertImageNotExists "mysql" 1
    assertImageNotExists "mysql" 2
-   assertImageExists "mysql" 3
+   assertImageNotExists "mysql" 3
    assertImageExists "mysql" 4
    assertImageExists "mysql" 5
 

--- a/test/tests/clean_full_catalog.sh
+++ b/test/tests/clean_full_catalog.sh
@@ -61,13 +61,13 @@ consul 20 _
 elasticsearch 1 _
 dummybox 10 _
 mongo 1 _
-postgres 0 `date +%d.%m.%Y`
+postgres 0 `date +%%Y%m%d`
 redis:2 0 _
 EOF
 
    # run cleanreg with --clean-full-catalog -k 2
    # keeping 2 images of alpine and mysql, because they are not in the test.conf
-   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -vvv --clean-full-catalog -k 2 -re -d `date +%d.%m.`$((`date +%Y`+1))
+   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -vvv --clean-full-catalog -k 2 -re -d $((`date +%Y`+1))`date +%m%d`
 
    assertImageExists "consul" 1
    assertImageExists "consul" 2

--- a/test/tests/clean_full_catalog.sh
+++ b/test/tests/clean_full_catalog.sh
@@ -19,10 +19,12 @@ test_CleanFullCatalog_uses_keepNumber_for_all_repos_if_not_specified_in_confFile
    #setup testdata
    createTestdata "consul" 1 3
    createTestdata "elasticsearch" 1 3
-   createTestdata "alpine" 1 3
-   createTestdata "mysql" 1 4
+   createTestdata "alpine" 1 4
+   createTestdata "mysql" 1 5
    createTestdata "mongo" 1 2
-   
+   createTestdata "postgres" 1 3
+   createTestdata "redis" 1 3
+
    assertImageExists "consul" 1
    assertImageExists "consul" 2
    assertImageExists "consul" 3
@@ -34,26 +36,38 @@ test_CleanFullCatalog_uses_keepNumber_for_all_repos_if_not_specified_in_confFile
    assertImageExists "alpine" 1
    assertImageExists "alpine" 2
    assertImageExists "alpine" 3
-   
+   assertImageExists "alpine" 4
+
    assertImageExists "mysql" 1
    assertImageExists "mysql" 2
    assertImageExists "mysql" 3
    assertImageExists "mysql" 4
+   assertImageExists "mysql" 5
 
    assertImageExists "mongo" 1
    assertImageExists "mongo" 2
 
+   assertImageExists "postgres" 1
+   assertImageExists "postgres" 2
+   assertImageExists "postgres" 3
+
+   assertImageExists "redis" 1
+   assertImageExists "redis" 2
+   assertImageExists "redis" 3
+
    # setup conf file
    tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
-consul 20
-elasticsearch 1
-dummybox 10 
-mongo 1
+consul 20 _ _
+elasticsearch 1 _ _
+dummybox 10 _ _
+mongo 1 _ _
+postgres 0 _ `date +%d.%m.%Y`
+redis 0 2 _
 EOF
 
    # run cleanreg with --clean-full-catalog -k 2
    # keeping 2 images of alpine and mysql, because they are not in the test.conf
-   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -vvv --clean-full-catalog -k 2
+   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -vvv --clean-full-catalog -k 2 -re 2 -d `date +%d.%m.`$((`date +%Y`+1))
    
    assertImageExists "consul" 1
    assertImageExists "consul" 2
@@ -66,14 +80,24 @@ EOF
    assertImageNotExists "alpine" 1
    assertImageExists "alpine" 2
    assertImageExists "alpine" 3
-   
+   assertImageExists "alpine" 4
+
    assertImageNotExists "mysql" 1
-   assertImageNotExists "mysql" 2
-   assertImageExists "mysql" 3
+   assertImageExists "mysql" 2
+   assertImageNotExists "mysql" 3
    assertImageExists "mysql" 4
+   assertImageExists "mysql" 5
 
    assertImageNotExists "mongo" 1
    assertImageExists "mongo" 2
+
+   assertImageExists "postgres" 1
+   assertImageExists "postgres" 2
+   assertImageExists "postgres" 3
+
+   assertImageNotExists "redis" 1
+   assertImageExists "redis" 2
+   assertImageNotExists "redis" 3
 
 }
 

--- a/test/tests/clean_full_catalog.sh
+++ b/test/tests/clean_full_catalog.sh
@@ -57,18 +57,18 @@ test_CleanFullCatalog_uses_keepNumber_for_all_repos_if_not_specified_in_confFile
 
    # setup conf file
    tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
-consul 20 _ _
-elasticsearch 1 _ _
-dummybox 10 _ _
-mongo 1 _ _
-postgres 0 _ `date +%d.%m.%Y`
-redis 0 2 _
+consul 20 _
+elasticsearch 1 _
+dummybox 10 _
+mongo 1 _
+postgres 0 `date +%d.%m.%Y`
+redis:2 0 _
 EOF
 
    # run cleanreg with --clean-full-catalog -k 2
    # keeping 2 images of alpine and mysql, because they are not in the test.conf
-   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -vvv --clean-full-catalog -k 2 -re 2 -d `date +%d.%m.`$((`date +%Y`+1))
-   
+   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -vvv --clean-full-catalog -k 2 -re -d `date +%d.%m.`$((`date +%Y`+1))
+
    assertImageExists "consul" 1
    assertImageExists "consul" 2
    assertImageExists "consul" 3
@@ -78,13 +78,13 @@ EOF
    assertImageExists "elasticsearch" 3
    
    assertImageNotExists "alpine" 1
-   assertImageExists "alpine" 2
+   assertImageNotExists "alpine" 2
    assertImageExists "alpine" 3
    assertImageExists "alpine" 4
 
    assertImageNotExists "mysql" 1
-   assertImageExists "mysql" 2
-   assertImageNotExists "mysql" 3
+   assertImageNotExists "mysql" 2
+   assertImageExists "mysql" 3
    assertImageExists "mysql" 4
    assertImageExists "mysql" 5
 
@@ -95,9 +95,9 @@ EOF
    assertImageExists "postgres" 2
    assertImageExists "postgres" 3
 
-   assertImageNotExists "redis" 1
-   assertImageExists "redis" 2
-   assertImageNotExists "redis" 3
+   assertImageExists "redis" 1
+   assertImageNotExists "redis" 2
+   assertImageExists "redis" 3
 
 }
 

--- a/test/tests/cleanreg_config_check.sh
+++ b/test/tests/cleanreg_config_check.sh
@@ -27,28 +27,58 @@ test_k_has_to_be_positive() {
    assertEquals "cleanreg.py: error: [-k] has to be a positive integer!" "$lastLine"
 }
 
+test_d_has_to_be_valid() {
+   lastLine=$(runCleanreg -n abc -d 01-01-2000 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-d] format should be DD.MM.YYYY" "$lastLine"
+}
+
 test_n_and_k_works() {  
    lastLine=$(runCleanreg -n abc -k 1 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
 
-test_n_doesnt_work_without_k() {  
-   lastLine=$(runCleanreg -n abc 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+test_n_and_re_works() {
+   lastLine=$(runCleanreg -n abc -re 1 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k]." "$lastLine"
+   assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
 
-test_cf_doesnt_work_without_k() {  
+test_n_and_d_works() {
+   lastLine=$(runCleanreg -n abc -d 01.01.2000 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "Aborted by user or nothing to delete." "$lastLine"
+}
+
+test_n_doesnt_work_without_k_re_or_d() {
+   lastLine=$(runCleanreg -n abc 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
+}
+
+test_cf_doesnt_work_without_k_re_or_d() {
    lastLine=$(runCleanreg -cf 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k]." "$lastLine"
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
 }
 
 test_k_doesnt_work_without_cf_or_n() {  
    lastLine=$(runCleanreg -k 2 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k]." "$lastLine"
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
+}
+
+test_re_doesnt_work_without_cf_or_n() {
+   lastLine=$(runCleanreg -re 2 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
+}
+
+test_d_doesnt_work_without_cf_or_n() {
+   lastLine=$(runCleanreg -d 01.01.2000 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   echo $lastLine
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
 }
 
 test_n_and_f_cant_be_used_together() {  
@@ -83,7 +113,7 @@ test_f_with_k_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc 2 notmatching `date +%d.%m.`$((`date +%Y`+1))" > $CLEANREG_WORKSPACE/test.conf
+   echo "abc 2 _ _" > $CLEANREG_WORKSPACE/test.conf
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
    assertImageNotExists "abc" 1
    assertImageNotExists "abc" 2
@@ -100,8 +130,7 @@ test_f_with_regex_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc 0 1|2 `date +%d.%m.`$((`date +%Y`+1))" > $CLEANREG_WORKSPACE/test.conf
-   cat $CLEANREG_WORKSPACE/test.conf
+   echo "abc 0 1|2 _" > $CLEANREG_WORKSPACE/test.conf
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
    assertImageExists "abc" 1
    assertImageExists "abc" 2
@@ -118,7 +147,7 @@ test_f_with_date_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc 0 notmatching `date +%d.%m.%Y`" > $CLEANREG_WORKSPACE/test.conf
+   echo "abc 0 _ `date +%d.%m.%Y`" > $CLEANREG_WORKSPACE/test.conf
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
    assertImageExists "abc" 1
    assertImageExists "abc" 2

--- a/test/tests/cleanreg_config_check.sh
+++ b/test/tests/cleanreg_config_check.sh
@@ -7,7 +7,11 @@ oneTimeSetUp() {
    createRegistryImages
    createCleanregImage
    startRegistry
-   echo "abc:\n    keepimages: 2\n    date: `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
+   tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
+abc:
+    keepimages: 2
+    date: `date +%Y%m%d`
+EOF
 }
 
 oneTimeTearDown() {
@@ -113,7 +117,10 @@ test_f_with_k_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc 2 _" > $CLEANREG_WORKSPACE/test.conf
+   tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
+abc:
+    keepimages: 2
+EOF
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
    assertImageNotExists "abc" 1
    assertImageNotExists "abc" 2
@@ -130,7 +137,10 @@ test_f_with_regex_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc:1|2 0 _" > $CLEANREG_WORKSPACE/test.conf
+   tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
+abc:
+    tag: 1|2
+EOF
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -re
    assertImageNotExists "abc" 1
    assertImageNotExists "abc" 2
@@ -147,7 +157,10 @@ test_f_with_date_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc 0 `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
+   tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
+abc:
+    date: `date +%Y%m%d`
+EOF
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
    assertImageExists "abc" 1
    assertImageExists "abc" 2

--- a/test/tests/cleanreg_config_check.sh
+++ b/test/tests/cleanreg_config_check.sh
@@ -7,7 +7,7 @@ oneTimeSetUp() {
    createRegistryImages
    createCleanregImage
    startRegistry
-   echo "abc 2 `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
+   echo "abc:\n    keepimages: 2\n    date: `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
 }
 
 oneTimeTearDown() {

--- a/test/tests/cleanreg_config_check.sh
+++ b/test/tests/cleanreg_config_check.sh
@@ -10,7 +10,7 @@ oneTimeSetUp() {
    tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
 abc:
     keepimages: 2
-    date: `date +%Y%m%d`
+    keepsince: `date +%Y%m%d`
 EOF
 }
 
@@ -31,10 +31,10 @@ test_k_has_to_be_positive() {
    assertEquals "cleanreg.py: error: [-k] has to be a positive integer!" "$lastLine"
 }
 
-test_d_has_to_be_valid() {
-   lastLine=$(runCleanreg -n abc -d 01012000 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+test_s_has_to_be_valid() {
+   lastLine=$(runCleanreg -n abc -s 123 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-d] format should be YYYYMMDD or YYYY-MM-DD" "$lastLine"
+   assertEquals "cleanreg.py: error: [-s] format does not match" "$lastLine"
 }
 
 test_n_and_k_works() {
@@ -50,7 +50,7 @@ test_n_and_re_works() {
 }
 
 test_n_and_d_works() {
-   lastLine=$(runCleanreg -n abc -d 2000-01-01 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -n abc -s 2000-01-01 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
@@ -58,31 +58,31 @@ test_n_and_d_works() {
 test_n_doesnt_work_without_k_re_or_d() {
    lastLine=$(runCleanreg -n abc 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-s]." "$lastLine"
 }
 
 test_cf_doesnt_work_without_k_re_or_d() {
    lastLine=$(runCleanreg -cf 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-s]." "$lastLine"
 }
 
 test_k_doesnt_work_without_cf_or_n() {
    lastLine=$(runCleanreg -k 2 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-s]." "$lastLine"
 }
 
 test_re_doesnt_work_without_cf_or_n() {
    lastLine=$(runCleanreg -re 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-s]." "$lastLine"
 }
 
-test_d_doesnt_work_without_cf_or_n() {
-   lastLine=$(runCleanreg -d 2000-01-01 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+test_s_doesnt_work_without_cf_or_n() {
+   lastLine=$(runCleanreg -s 2000-01-01 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
+   assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-s]." "$lastLine"
 }
 
 test_n_and_f_cant_be_used_together() {
@@ -159,7 +159,7 @@ test_f_with_date_works() {
 
    tee $CLEANREG_WORKSPACE/test.conf <<EOF > /dev/null
 abc:
-    date: `date +%Y%m%d`
+    keepsince: `date +%Y%m%d`
 EOF
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
    assertImageExists "abc" 1

--- a/test/tests/cleanreg_config_check.sh
+++ b/test/tests/cleanreg_config_check.sh
@@ -7,7 +7,7 @@ oneTimeSetUp() {
    createRegistryImages
    createCleanregImage
    startRegistry
-   echo "abc 2" > $CLEANREG_WORKSPACE/test.conf
+   echo "abc 2 regex `date +%d.%m.%y`" > $CLEANREG_WORKSPACE/test.conf
 }
 
 oneTimeTearDown() {
@@ -73,6 +73,58 @@ test_either_f_n_or_cf_has_to_be_used() {
    lastLine=$(runCleanreg 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n|-k] or [-cf|-k] or [-f] has to be used!" "$lastLine"
+}
+
+test_f_with_k_works() {
+   createTestdata "abc" 1 5
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+
+   echo "abc 2 notmatching `date +%d.%m.`$((`date +%Y`+1))" > $CLEANREG_WORKSPACE/test.conf
+   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
+   assertImageNotExists "abc" 1
+   assertImageNotExists "abc" 2
+   assertImageNotExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+}
+
+test_f_with_regex_works() {
+   createTestdata "abc" 1 5
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+
+   echo "abc 0 1|2 `date +%d.%m.`$((`date +%Y`+1))" > $CLEANREG_WORKSPACE/test.conf
+   cat $CLEANREG_WORKSPACE/test.conf
+   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageNotExists "abc" 3
+   assertImageNotExists "abc" 4
+   assertImageNotExists "abc" 5
+}
+
+test_f_with_date_works() {
+   createTestdata "abc" 1 5
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+
+   echo "abc 0 notmatching `date +%d.%m.%Y`" > $CLEANREG_WORKSPACE/test.conf
+   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
 }
 
 # load shunit2

--- a/test/tests/cleanreg_config_check.sh
+++ b/test/tests/cleanreg_config_check.sh
@@ -7,7 +7,7 @@ oneTimeSetUp() {
    createRegistryImages
    createCleanregImage
    startRegistry
-   echo "abc 2 regex `date +%d.%m.%y`" > $CLEANREG_WORKSPACE/test.conf
+   echo "abc 2 regex `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
 }
 
 oneTimeTearDown() {
@@ -147,7 +147,7 @@ test_f_with_date_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc 0 _ `date +%d.%m.%Y`" > $CLEANREG_WORKSPACE/test.conf
+   echo "abc 0 _ `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
    assertImageExists "abc" 1
    assertImageExists "abc" 2

--- a/test/tests/cleanreg_config_check.sh
+++ b/test/tests/cleanreg_config_check.sh
@@ -7,7 +7,7 @@ oneTimeSetUp() {
    createRegistryImages
    createCleanregImage
    startRegistry
-   echo "abc 2 regex `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
+   echo "abc 2 `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
 }
 
 oneTimeTearDown() {
@@ -15,38 +15,38 @@ oneTimeTearDown() {
   stopRegistry
 }
 
-test_n_and_f_cant_be_used_together() {  
+test_n_and_f_cant_be_used_together() {
    lastLine=$(runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -n abc 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] and [-f] cant be used together" "$lastLine"
 }
 
-test_k_has_to_be_positive() {  
+test_k_has_to_be_positive() {
    lastLine=$(runCleanreg -n abc -k -1 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-k] has to be a positive integer!" "$lastLine"
 }
 
 test_d_has_to_be_valid() {
-   lastLine=$(runCleanreg -n abc -d 01-01-2000 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -n abc -d 01012000 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
-   assertEquals "cleanreg.py: error: [-d] format should be DD.MM.YYYY" "$lastLine"
+   assertEquals "cleanreg.py: error: [-d] format should be YYYYMMDD or YYYY-MM-DD" "$lastLine"
 }
 
-test_n_and_k_works() {  
+test_n_and_k_works() {
    lastLine=$(runCleanreg -n abc -k 1 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
 
 test_n_and_re_works() {
-   lastLine=$(runCleanreg -n abc -re 1 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -n abc:1 -re 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
 
 test_n_and_d_works() {
-   lastLine=$(runCleanreg -n abc -d 01.01.2000 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -n abc -d 2000-01-01 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
@@ -63,43 +63,43 @@ test_cf_doesnt_work_without_k_re_or_d() {
    assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
 }
 
-test_k_doesnt_work_without_cf_or_n() {  
+test_k_doesnt_work_without_cf_or_n() {
    lastLine=$(runCleanreg -k 2 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
 }
 
 test_re_doesnt_work_without_cf_or_n() {
-   lastLine=$(runCleanreg -re 2 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -re 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
 }
 
 test_d_doesnt_work_without_cf_or_n() {
-   lastLine=$(runCleanreg -d 01.01.2000 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
+   lastLine=$(runCleanreg -d 2000-01-01 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] or [-cf] have to be used together with [-k], [-re] or [-d]." "$lastLine"
 }
 
-test_n_and_f_cant_be_used_together() {  
+test_n_and_f_cant_be_used_together() {
    lastLine=$(runCleanregPython -n abc -f $CLEANREG_WORKSPACE/test.conf 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n] and [-f] cant be used together" "$lastLine"
 }
 
-test_cf_and_f_can_be_used_together() {  
+test_cf_and_f_can_be_used_together() {
    lastLine=$(runCleanregPython -cf -k 2 -f $CLEANREG_WORKSPACE/test.conf 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
 
-test_f_works() {  
+test_f_works() {
    lastLine=$(runCleanregPython -f $CLEANREG_WORKSPACE/test.conf 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "Aborted by user or nothing to delete." "$lastLine"
 }
 
-test_either_f_n_or_cf_has_to_be_used() {  
+test_either_f_n_or_cf_has_to_be_used() {
    lastLine=$(runCleanreg 2>&1 | tail -n 1 | tr -dC '[:print:]\t\n')
    echo $lastLine
    assertEquals "cleanreg.py: error: [-n|-k] or [-cf|-k] or [-f] has to be used!" "$lastLine"
@@ -113,7 +113,7 @@ test_f_with_k_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc 2 _ _" > $CLEANREG_WORKSPACE/test.conf
+   echo "abc 2 _" > $CLEANREG_WORKSPACE/test.conf
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
    assertImageNotExists "abc" 1
    assertImageNotExists "abc" 2
@@ -130,13 +130,13 @@ test_f_with_regex_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc 0 1|2 _" > $CLEANREG_WORKSPACE/test.conf
-   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
-   assertImageExists "abc" 1
-   assertImageExists "abc" 2
-   assertImageNotExists "abc" 3
-   assertImageNotExists "abc" 4
-   assertImageNotExists "abc" 5
+   echo "abc:1|2 0 _" > $CLEANREG_WORKSPACE/test.conf
+   runCleanregPython -f $CLEANREG_WORKSPACE/test.conf -re
+   assertImageNotExists "abc" 1
+   assertImageNotExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
 }
 
 test_f_with_date_works() {
@@ -147,7 +147,7 @@ test_f_with_date_works() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   echo "abc 0 _ `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
+   echo "abc 0 `date +%Y%m%d`" > $CLEANREG_WORKSPACE/test.conf
    runCleanregPython -f $CLEANREG_WORKSPACE/test.conf
    assertImageExists "abc" 1
    assertImageExists "abc" 2

--- a/test/tests/simple_clean.sh
+++ b/test/tests/simple_clean.sh
@@ -53,6 +53,26 @@ testCleanASingleRepoKeepImages() {
    assertImageExists "abc" 5
 }
 
+testCleanASingleRepoRegex() {
+   startRegistry
+
+   #setup testdata
+   createTestdata "abc" 1 5
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+
+   #run cleanreg
+   runCleanreg -n abc -re 1 -i
+   assertImageExists "abc" 1
+   assertImageNotExists "abc" 2
+   assertImageNotExists "abc" 3
+   assertImageNotExists "abc" 4
+   assertImageNotExists "abc" 5
+}
+
 testCleanASingleRepoRemoveAllImagesWithOneDigest() {
    startRegistry
 

--- a/test/tests/simple_clean.sh
+++ b/test/tests/simple_clean.sh
@@ -85,7 +85,7 @@ testCleanASingleRepoDate() {
    assertImageExists "abc" 5
 
    #run cleanreg
-   runCleanreg -n abc -d date '+%d.%m.%y' -i
+   runCleanreg -n abc -d `date '+%d.%m.%Y'` -i
    assertImageExists "abc" 1
    assertImageExists "abc" 2
    assertImageExists "abc" 3

--- a/test/tests/simple_clean.sh
+++ b/test/tests/simple_clean.sh
@@ -65,7 +65,7 @@ testCleanASingleRepoRegex() {
    assertImageExists "abc" 5
 
    #run cleanreg
-   runCleanreg -n abc -re 1\|2 -i
+   runCleanreg -n abc:1\|2 -re  -i
    assertImageExists "abc" 1
    assertImageExists "abc" 2
    assertImageNotExists "abc" 3

--- a/test/tests/simple_clean.sh
+++ b/test/tests/simple_clean.sh
@@ -84,13 +84,29 @@ testCleanASingleRepoDate() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   #run cleanreg
-   runCleanreg -n abc -d `date '+%d.%m.%Y'` -i
+   #cleanreg with todays date sholdn't delete any images
+   runCleanreg -n abc -d `date '+%Y%m%d'` -i
    assertImageExists "abc" 1
    assertImageExists "abc" 2
    assertImageExists "abc" 3
    assertImageExists "abc" 4
    assertImageExists "abc" 5
+
+   #same test with different date format
+   runCleanreg -n abc -d `date '+%Y-%m-%d'` -i
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+
+   #cleanreg with a date in the future should delete all images
+   runCleanreg -n abc -d $((`date +%Y`+1))`date +%m%d` -i
+   assertImageNotExists "abc" 1
+   assertImageNotExists "abc" 2
+   assertImageNotExists "abc" 3
+   assertImageNotExists "abc" 4
+   assertImageNotExists "abc" 5
 }
 
 testCleanASingleRepoRemoveAllImagesWithOneDigest() {

--- a/test/tests/simple_clean.sh
+++ b/test/tests/simple_clean.sh
@@ -64,13 +64,21 @@ testCleanASingleRepoRegex() {
    assertImageExists "abc" 4
    assertImageExists "abc" 5
 
-   #run cleanreg
-   runCleanreg -n abc:1\|2 -re  -i
-   assertImageExists "abc" 1
-   assertImageExists "abc" 2
-   assertImageNotExists "abc" 3
-   assertImageNotExists "abc" 4
-   assertImageNotExists "abc" 5
+   #cleanreg with a regex matching abc:1 and abc:2 will delete those
+   runCleanreg -n abc:1\|2 -re -i
+   assertImageNotExists "abc" 1
+   assertImageNotExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+
+   #regex is not enabled so the tagname won't match any
+   runCleanreg -n abc:3\|4 -i
+   assertImageNotExists "abc" 1
+   assertImageNotExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
 }
 
 testCleanASingleRepoDate() {

--- a/test/tests/simple_clean.sh
+++ b/test/tests/simple_clean.sh
@@ -65,12 +65,33 @@ testCleanASingleRepoRegex() {
    assertImageExists "abc" 5
 
    #run cleanreg
-   runCleanreg -n abc -re 1 -i
+   runCleanreg -n abc -re 1\|2 -i
    assertImageExists "abc" 1
-   assertImageNotExists "abc" 2
+   assertImageExists "abc" 2
    assertImageNotExists "abc" 3
    assertImageNotExists "abc" 4
    assertImageNotExists "abc" 5
+}
+
+testCleanASingleRepoDate() {
+   startRegistry
+
+   #setup testdata
+   createTestdata "abc" 1 5
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+
+   #run cleanreg
+   runCleanreg -n abc -d date '+%d.%m.%y' -i
+   docker images
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
 }
 
 testCleanASingleRepoRemoveAllImagesWithOneDigest() {

--- a/test/tests/simple_clean.sh
+++ b/test/tests/simple_clean.sh
@@ -93,7 +93,7 @@ testCleanASingleRepoDate() {
    assertImageExists "abc" 5
 
    #cleanreg with todays date sholdn't delete any images
-   runCleanreg -n abc -d `date '+%Y%m%d'` -i
+   runCleanreg -n abc -s $((`date +%Y`-1))`date '+%m%d'` -i
    assertImageExists "abc" 1
    assertImageExists "abc" 2
    assertImageExists "abc" 3
@@ -101,7 +101,23 @@ testCleanASingleRepoDate() {
    assertImageExists "abc" 5
 
    #same test with different date format
-   runCleanreg -n abc -d `date '+%Y-%m-%d'` -i
+   runCleanreg -n abc -s $((`date +%Y`-1))`date '+-%m-%d'` -i
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+
+   #same test with different date format
+   runCleanreg -n abc -s $((`date +%Y`-1))`date '+%m%dT000000'` -i
+   assertImageExists "abc" 1
+   assertImageExists "abc" 2
+   assertImageExists "abc" 3
+   assertImageExists "abc" 4
+   assertImageExists "abc" 5
+
+   #same test with different date format
+   runCleanreg -n abc -s $((`date +%Y`-1))`date '+-%m-%dT00:00:00'` -i
    assertImageExists "abc" 1
    assertImageExists "abc" 2
    assertImageExists "abc" 3
@@ -109,7 +125,7 @@ testCleanASingleRepoDate() {
    assertImageExists "abc" 5
 
    #cleanreg with a date in the future should delete all images
-   runCleanreg -n abc -d $((`date +%Y`+1))`date +%m%d` -i
+   runCleanreg -n abc -s $((`date +%Y`+1))`date +%m%d` -i
    assertImageNotExists "abc" 1
    assertImageNotExists "abc" 2
    assertImageNotExists "abc" 3

--- a/test/tests/simple_clean.sh
+++ b/test/tests/simple_clean.sh
@@ -86,7 +86,6 @@ testCleanASingleRepoDate() {
 
    #run cleanreg
    runCleanreg -n abc -d date '+%d.%m.%y' -i
-   docker images
    assertImageExists "abc" 1
    assertImageExists "abc" 2
    assertImageExists "abc" 3


### PR DESCRIPTION
I've added options to keep tags if they match a regular expression or if they were created after a specified date. E.g.:
`./cleanreg.py -r http://192.168.56.2:5000 -n mysql -k 5 -i `**`-re .*release.* -d 01.01.2018`**
will keep the 5 latest but also tags containing the word "release" as well as all those created since 01.01.2018.

Configs have to be rewritten to match the additional parameters with the option to use an underscore to ignore the parameter:
`<repo> <k> <re> <d>`

E.g.: `mysql 5 _ _` keeps the 5 latest and does not consider regular expressions or dates.