### PR TITLE
Implenent a --skip-tls-verify attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Information about the needed garbage collection is described at [https://docs.do
 
 ## History
 
+* v0.7.1 - Added a `--skip-tls-verify` attribute
 * v0.7 - This is a release which breaks some stuff (configuration file is now yaml based), adding new options for keeping images (e.g. `--since`, `--regex`) (thanks to @JulianSauer for his [PR10](https://github.com/hcguersoy/cleanreg/pull/10))
 * v0.6 - add `-cf` flag which allows to clean up all repos in a registry (thanks @kekru for his PR)
 * v0.5 - fix for issue [#8](https://github.com/hcguersoy/cleanreg/issues/8) which resulted in deleting more layers then intended; performance improvements; added `--metadata-workers` attribute
@@ -94,6 +95,9 @@ optional arguments:
   -c CACERT, --cacert CACERT
                         Path to a valid CA certificate file. This is needed if
                         self signed TLS is used in the registry server.
+  -sv, --skip-tls-verify
+                        If set insecure TLS is allowed, so no need for
+                        a valid cert to verify.
   -i, --ignore-ref-tags
                         Ignore a digest if it is referenced multiple times in
                         the whole registry server. In this case, a list of all

--- a/cleanreg.py
+++ b/cleanreg.py
@@ -65,6 +65,7 @@ def parse_arguments():
                                                   "regarding tags, dates and how many images to keep.")
     parser.add_argument('-c', '--cacert', help="Path to a valid CA certificate file. This is needed if self signed "
                                                "TLS is used in the registry server.", default=None)
+    parser.add_argument('-sv', '--skip-tls-verify', help="If set insecure TLS is allowed, so no need for a valid cert to verify.", default=False, action='store_true', dest="skip_tls_verify")
     parser.add_argument('-i', '--ignore-ref-tags', help="Ignore a digest if it is referenced multiple times "
                                                         "in the whole registry server. In this case, a list of all "
                                                         "repositories and their images will be retrieved which can be "
@@ -664,6 +665,9 @@ if __name__ == '__main__':
         if args.verbose > 1:
             print "Will exclude registryserver location from proxy:", urlparse(args.registry).netloc
         os.environ['no_proxy'] = urlparse(args.registry).netloc
+
+    if args.skip_tls_verify:
+        args.cacert = False
 
     # initially check if we've a v2 registry server
     if is_v2_registry(args.verbose, reg_server_api, args.cacert) is False:


### PR DESCRIPTION
I tried to add a valid certificate with cacert option from /var/run/certs/cacert.pem - and it failed. I think that is not a critical component where a valid certificate isn't nessesary. I missed the skip-tls-verify attribute - so i add one.